### PR TITLE
Fix link to Getting Started section of User’s Guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@ start {
 
         <p>
             The result of running this program is shown in the image below. See the
-            <a href="docs/guide/gettingStarted.html">Getting Started</a> section of the user guide for
+            <a href="docs/index.html#_getting_started">Getting Started</a> section of the user guide for
             more information.
         </p>
         <img class="screenshot" src="resources/img/hello_world.png" alt="GroovyFX Hello World"/>


### PR DESCRIPTION
Fix broken link to **Getting Started** section of **User’s Guide**.
