### PR TITLE
Add a README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# GroovyFX Website Source
+
+This repository contains the source for the [GroovyFX website](https://groovyfx.org) – not all of it though,
+for example the user manual source is held in the
+[GroovyFX repository](https://github.com/groovyfx-project/groovyfx). Commits to this repository will show up
+immediately on the website.


### PR DESCRIPTION
It is standard practice to have a README on GitHub repositories, and this will get rid of the prompt to create one.
