### PR TITLE
Update mailing list link to point to "Mailing Lists" wiki page

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
             <!--<p><a href="http://groovy.codehaus.org/GroovyFX">User Guide</a></p>-->
             <p><a href="docs/index.html">User Guide</a></p>
             <p><a href="https://github.com/groovyfx-project/groovyfx/issues">Issue Tracker</a></p>
-            <p><a href="http://groovy-lang.org/mailing-lists.html">Mailing Lists</a></p>
+            <p><a href="https://github.com/groovyfx-project/groovyfx/wiki/Mailing-Lists">Mailing Lists</a></p>
             <p><a href="https://dl.bintray.com/groovyfx/maven/org/groovyfx/groovyfx/8.0.0/groovyfx-8.0.0.jar">Download</a></p>
         </div>
 


### PR DESCRIPTION
Update mailing list link to point to "Mailing Lists" wiki page (rather than directly to the Groovy-lang site mailing lists page without explanation)
